### PR TITLE
send request in protect.ts

### DIFF
--- a/server/protect.ts
+++ b/server/protect.ts
@@ -7,7 +7,7 @@ export function protect(handler: NextApiHandler): NextApiHandler {
     if (session) {
       await handler(req, res);
     } else {
-      res.status(401);
+      res.status(401).send(undefined);
     }
   };
 }


### PR DESCRIPTION
we forgot to call .send() in protect.ts, so the API was resolving without having sent the request.