### PR TITLE
Improve Test Infra/Docs

### DIFF
--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -1,0 +1,18 @@
+name: Jest
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main, production ]
+
+jobs:
+  jest-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install
+        uses: bahmutov/npm-install@v1
+      - run: yarn test:unit

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ yarn-error.log*
 
 # mongo data
 /infrastructure/dev/mongo-data
+
+# cypress
+/cypress/screenshots/
+/cypress/videos/
+

--- a/cypress/utils.ts
+++ b/cypress/utils.ts
@@ -18,7 +18,7 @@ export const createApplicantAndLogin = async (email: string): Promise<void> => {
   await createUserAndLogin({ email, isAdmin: false });
 };
 
-export const checkLoggedIn = () => {
+export const checkLoggedIn = (): void => {
   cy.get('header').should('contain', 'Application');
   cy.get('header').should('contain', 'Team');
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "lint": "next lint",
     "prepare": "husky install",
-    "test": "jest"
+    "test:unit": "jest tests",
+    "test:integration": "cypress run"
   },
   "dependencies": {
     "@next-auth/mongodb-adapter": "0.0.2-next.281",
@@ -41,7 +42,6 @@
     "husky": ">=6",
     "jest": "^27.2.5",
     "lint-staged": ">=10",
-    "next-test-api-route-handler": "^2.1.2",
     "prettier": "^2.3.2",
     "ts-jest": "^27.0.7",
     "tsc-files": "^1.1.2",
@@ -54,6 +54,21 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "preset": "ts-jest"
+    "preset": "ts-jest",
+    "globals": {
+      "ts-jest": {
+        "tsconfig": {
+          "skipLibCheck": true,
+          "strict": true,
+          "noEmit": true,
+          "esModuleInterop": true,
+          "module": "esnext",
+          "moduleResolution": "node",
+          "resolveJsonModule": true,
+          "isolatedModules": true,
+          "jsx": "react-jsx"
+        }
+      }
+    }
   }
 }

--- a/tests/registration.test.ts
+++ b/tests/registration.test.ts
@@ -9,11 +9,6 @@ import { Checkboxes, Dropdown, LongText, QuestionType, ShortText } from '../comm
 import Joi from 'joi';
 import { isAfterRegistrationClosed, isBeforeRegistrationOpens } from '../common/dateUtils';
 
-// if you're running into the following error when running tests:
-// SyntaxError: Unexpected token '<'
-// make sure "jsx" is set to "react" in tsconfig.json
-// nextjs automatically sets it to "preserve"
-
 // convenience constructors
 const n = (name: string) => ({ name });
 const cb = (d?: Partial<Checkboxes>): Checkboxes => {

--- a/tests/registration.test.ts
+++ b/tests/registration.test.ts
@@ -1,21 +1,13 @@
+import { describe, expect, test } from '@jest/globals';
 import {
   convertCheckboxesToJoiSchema,
   convertDropdownToJoiSchema,
   convertLongTextToJoiSchema,
   makeQuestionResponseSchemas,
 } from '../server/validators';
-import {
-  Checkboxes,
-  Dropdown,
-  LongText,
-  QuestionType,
-  ShortText,
-} from '../common/types';
+import { Checkboxes, Dropdown, LongText, QuestionType, ShortText } from '../common/types';
 import Joi from 'joi';
-import {
-  isAfterRegistrationClosed,
-  isBeforeRegistrationOpens,
-} from '../common/dateUtils';
+import { isAfterRegistrationClosed, isBeforeRegistrationOpens } from '../common/dateUtils';
 
 // if you're running into the following error when running tests:
 // SyntaxError: Unexpected token '<'
@@ -28,8 +20,7 @@ const cb = (d?: Partial<Checkboxes>): Checkboxes => {
   const dfault: Checkboxes = {
     type: QuestionType.Checkboxes,
     id: '1',
-    content:
-      'Your top two most proficient languages. Select at least 1, but no more than 2.',
+    content: 'Your top two most proficient languages. Select at least 1, but no more than 2.',
     minNumber: 1,
     maxNumber: 2,
     options: ['English', 'Java', 'Typescript', 'Japanese'].map(n),
@@ -136,9 +127,7 @@ describe('registration endpoint schema tests', () => {
     it("doesn't throw when text length is ok", () => {
       expect(() => Joi.assert(ten, lts1)).not.toThrow();
       expect(() => Joi.assert(fifty, lts1)).not.toThrow();
-      expect(() =>
-        Joi.assert("some normal length that's in the middle", lts1)
-      ).not.toThrow();
+      expect(() => Joi.assert("some normal length that's in the middle", lts1)).not.toThrow();
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,11 +2035,6 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-cookie@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
-  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
-
 copy-to-clipboard@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
@@ -3663,14 +3658,6 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-isomorphic-unfetch@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
-  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
-  dependencies:
-    node-fetch "^2.6.1"
-    unfetch "^4.2.0"
-
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -4668,16 +4655,6 @@ next-auth@4.0.0-beta.4:
     preact "^10.5.13"
     preact-render-to-string "^5.1.19"
 
-next-test-api-route-handler@^2.1.2:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/next-test-api-route-handler/-/next-test-api-route-handler-2.3.4.tgz#748787ca4cf6b863c99ec2e695abde9ae887af54"
-  integrity sha512-hr92BcHjvRBlNnnCrqobvSiztOh1L5nn0TNKim00wecxxsCX2OM2QAxvmxr+vPsWr7VwrKfRNttfENmjKYsiCA==
-  dependencies:
-    cookie "^0.4.1"
-    debug "^4.3.2"
-    isomorphic-unfetch "^3.1.0"
-    test-listen "^1.1.0"
-
 next@^11.0.1:
   version "11.1.2"
   resolved "https://registry.yarnpkg.com/next/-/next-11.1.2.tgz#527475787a9a362f1bc916962b0c0655cc05bc91"
@@ -4743,13 +4720,6 @@ node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
-node-fetch@^2.6.1:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
-  dependencies:
-    whatwg-url "^5.0.0"
 
 node-html-parser@1.4.9:
   version "1.4.9"
@@ -6440,11 +6410,6 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-test-listen@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/test-listen/-/test-listen-1.1.0.tgz#2ba614d96c3bc9157469003027b42a495dd83b6a"
-  integrity sha512-OyEVi981C1sb9NX1xayfgZls3p8QTDRwp06EcgxSgd1kktaENBW8dO15i8v/7Fi15j0IYQctJzk5J+hyEBId2w==
-
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -6553,11 +6518,6 @@ tr46@^3.0.0:
   integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
   dependencies:
     punycode "^2.1.1"
-
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
 traverse-chain@~0.1.0:
   version "0.1.0"
@@ -6692,11 +6652,6 @@ unbox-primitive@^1.0.1:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
-
-unfetch@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
-  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 universalify@^0.1.2:
   version "0.1.2"
@@ -6845,11 +6800,6 @@ watchpack@2.1.1:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
-
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -6889,14 +6839,6 @@ whatwg-url@^11.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
This PR:

- fixes clashing jest/cypress namespaces
- fixes jest tests (previously were erroring out with syntax error due to `jsx: preserve` in tsconfig)
- adds two new commands, `yarn test:unit` and `yarn test:integration`
- adds a github action for unit tests
- when logging in, make sure there is only one matching verification token in db (avoid erroring)

TODO

- ~add docs (cypress, docker)~ -> saving this for another time
- dev login?
- add an alias for saving login cookie?