### PR TITLE
added caris text changes

### DIFF
--- a/common/questions.tsx
+++ b/common/questions.tsx
@@ -407,7 +407,7 @@ export const PostAcceptanceFormSections: Array<QuestionSection | QuestionDefinit
   ),
   makeSection(
     <>Now the fun stuff!</>,
-    "Even though our event will be mostly virtual, we still plan on getting our awesome swag to our attendees! We will be having Swag Outpost stations on certain days at Northeastern University's campus in Boston. For those unable to pick up in Boston, we will try our best to ship swag to you if you're within the continental US."
+    "Even though our event will be mostly virtual, we still plan on getting our awesome swag to our attendees! We will be having Swag Outpost stations on certain days at Northeastern University's campus in Boston. For those unable to pick up in Boston, we will try our best to ship swag to you if you're within the continental US. If you would like to cover your international shipping costs for swag shipping costs, please email team@hackbeanpot.com with your mailing address."
   ),
   makeCheckbox(
     'swag',
@@ -420,7 +420,7 @@ export const PostAcceptanceFormSections: Array<QuestionSection | QuestionDefinit
     [
       'T-shirt: our annual event shirt',
       'Sticker sheet: classic HBP logo sticker with special space themed stickers',
-      'Cafe glasses: clear glass coffee cups with HBP logo printed on them',
+      'Cafe glasses: clear glass coffee cups with HBP logo printed on them (Cafe glasses will be an in-person only option due to them being unable to being shipped',
       'All of the above',
       'None or N/A',
     ],
@@ -430,8 +430,9 @@ export const PostAcceptanceFormSections: Array<QuestionSection | QuestionDefinit
   makeShortText(
     'accomodations',
     <div>
-      <p>Are there any accommodations (e.g. dietary restrictions) you would need from us?</p>
-      For snacks!
+      <p>
+        Are there any accommodations (e.g. dietary restrictions) you would need from us for snacks?
+      </p>
     </div>,
     false,
     'accomodations'
@@ -441,7 +442,9 @@ export const PostAcceptanceFormSections: Array<QuestionSection | QuestionDefinit
     <div>
       <p>
         If you are in the Boston area, would you be able to pick up your swag box at a location on
-        the Northeastern University campus in January?
+        the Northeastern University campus from January 29 - February 5? A separate Google form for
+        swag outpost pickup will be sent to your email at a later time to coordinate Swag Pickup
+        timeslots.
       </p>
       It would really help us out :{"'"}) Shipping is expensive these days but we want to get you
       the BEST swag out there!

--- a/components/application/PostAcceptanceForm.tsx
+++ b/components/application/PostAcceptanceForm.tsx
@@ -43,7 +43,8 @@ const AttendingForm: React.FC<AttendingFormProps> = ({ setAttendingState }) => {
   };
   return (
     <>
-      <p>
+      <p>This RSVP form is DUE for Round 1 Acceptances: Jan 21 11:59 PM EST.</p>
+      <p style={{ textAlign: 'center' }}>
         Please select if you will be attending HackBeanpot on the weekend of February 11 - 13th,
         2022. If you cannot make it, please select {'"No"'} so that we can admit others on the wait
         list instead.


### PR DESCRIPTION
- add a This RSVP form is DUE for Round 1 Acceptances: Jan 21 11:59 PM EST at the top  of the Post Acceptance Form page?

- Under Swag list for Cafe glasses add in parentheses or *Note: after cafe glass description: Cafe glasses will be an in-person only option due to them being unable to being shipped

- at end of swag first par: If you would like to cover your international shipping costs for swag shipping costs, please email team@hackbeanpot.com with your mailing address

- change the for snacks! part of dietary restrictions q: Instead, add to end of question: For snacks!

- Swag box: change in January to Jan 29-Feb 5. And add to end of first par: A separate Google form for swag outpost pickup will be sent to your email  at a later time to coordinate Swag Pickup timeslots.