### PR TITLE
Map post acceptance questions to user

### DIFF
--- a/common/questions.tsx
+++ b/common/questions.tsx
@@ -10,6 +10,7 @@ import {
   Dropdown,
   LongText,
   QuestionDefinition,
+  QuestionResponseField,
   QuestionSection,
   QuestionType,
   ShortText,
@@ -26,7 +27,7 @@ const longTextMaxLength = 3000;
 
 // convenience constructors for questions (constructors in java)
 export function makeCheckbox(
-  field: keyof User,
+  field: QuestionResponseField,
   content: ReactNode,
   options: Array<string>,
   required: boolean,
@@ -46,7 +47,7 @@ export function makeCheckbox(
 }
 
 export function makeShortText(
-  field: keyof User,
+  field: QuestionResponseField,
   content: ReactNode,
   required: boolean,
   placeholder?: string
@@ -65,7 +66,7 @@ export function makeShortText(
 }
 
 export function makeDropdown(
-  field: keyof User,
+  field: QuestionResponseField,
   content: ReactNode,
   options: Array<string>,
   required: boolean,
@@ -83,7 +84,11 @@ export function makeDropdown(
   };
 }
 
-export function makeLongText(field: keyof User, content: ReactNode, required: boolean): LongText {
+export function makeLongText(
+  field: QuestionResponseField,
+  content: ReactNode,
+  required: boolean
+): LongText {
   questionCount++;
   return {
     field,

--- a/common/types.ts
+++ b/common/types.ts
@@ -4,12 +4,23 @@ import { ReactNode } from 'react';
  * @param applicationStatus deez nuts :0
  */
 export interface User {
+  email: string;
+  applicationResponses?: ApplicationResponses;
+  postAcceptanceResponses?: PostAcceptanceResponses;
+  isAdmin: boolean;
+  applicationStatus: ApplicationStatus;
+  // Decision status might not exist because of backwards compatibility
+  decisionStatus?: DecisionStatus;
+  rsvpStatus: RSVPStatus;
+  responses?: Array<QuestionResponse>; // legacy
+}
+
+export interface ApplicationResponses {
   name?: string;
   gender?: Gender;
   unlistedGender?: string;
   school?: string;
   unlistedSchool?: string;
-  email: string;
   ethnicities?: Array<Ethnicity>;
   education?: Education;
   yearOfEducation?: YearOfEducation;
@@ -26,13 +37,16 @@ export interface User {
   interestedWorkshops?: Array<string>;
   applyingWithTeam?: string;
   interestedInTeamFormation?: string;
+}
+
+export interface PostAcceptanceResponses {
   firstName?: string;
   lastName?: string;
   adult?: string;
   adultSignature?: string;
   minorSignature?: string;
   guardianSignature?: string;
-  swag?: string[];
+  swag?: Array<string>;
   accomodations?: string;
   pickUpSwag?: string;
   address?: string;
@@ -41,14 +55,9 @@ export interface User {
   wonLottery?: string;
   themePark?: string;
   celebrity?: string;
-  isAdmin: boolean;
-  applicationStatus: ApplicationStatus;
-  // Decision status might not exist because of backwards compatibility
-  decisionStatus?: DecisionStatus;
-  rsvpStatus: RSVPStatus;
-  responses?: Array<QuestionResponse>;
-  postAcceptanceResponses?: Array<QuestionResponse>;
 }
+
+export type QuestionResponseField = keyof ApplicationResponses | keyof PostAcceptanceResponses;
 
 export type SingletonDefinition = DateSingleton | ShowDecisionSingleton;
 
@@ -139,7 +148,7 @@ export type QuestionSection = {
 export type QuestionId = string;
 
 interface IQuestion {
-  field: keyof User;
+  field: QuestionResponseField;
   content: ReactNode;
   id: QuestionId;
   required: boolean;
@@ -187,7 +196,7 @@ export type QuestionResponse = string | Array<string> | null;
  * @param responses mapping from question id to response value
  */
 export type RegistrationApiRequest = {
-  fields: Array<keyof User | string>;
+  fields: Array<keyof ApplicationResponses>;
   responses: Array<QuestionResponse>;
 };
 export type RegistrationApiResponse = RegistrationApiRequest;
@@ -212,5 +221,6 @@ export type SingleApplicantApiResponse = {
 
 export type PostAcceptanceApiRequest = {
   rsvpStatus: Exclude<RSVPStatus, RSVPStatus.Unconfirmed>;
+  fields?: Array<keyof PostAcceptanceResponses>;
   responses?: Array<QuestionResponse>;
 };

--- a/components/admin-tabs/Applicants.tsx
+++ b/components/admin-tabs/Applicants.tsx
@@ -45,7 +45,9 @@ const columns = [
       value: name,
     })),
     render: (_: string, record: SingleRecordType) =>
-      record.school === 'Other' ? record.unlistedSchool : record.school,
+      record.applicationResponses?.school === 'Other'
+        ? record.applicationResponses.unlistedSchool
+        : record.applicationResponses?.school,
     sorter: true,
     editable: false,
   },
@@ -218,7 +220,7 @@ const downloadPostAcceptanceCsv = async (props: DownloadProps) =>
     props,
     fields,
     PostAcceptanceFormQuestions,
-    (u) => u.postAcceptanceResponses,
+    (u) => Object.values(u.postAcceptanceResponses ?? {}),
     'post-acceptance.csv'
   );
 

--- a/components/application/ApplicationForm.tsx
+++ b/components/application/ApplicationForm.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { ApplicationStatus, QuestionResponse } from '../../common/types';
+import { ApplicationResponses, ApplicationStatus, QuestionResponse } from '../../common/types';
 import {
   getApplicantResponses,
   getRegistrationClosed,
@@ -70,7 +70,7 @@ export const ApplicationForm = (): ReactElement => {
   );
 
   const onSubmit = async (values: Record<string, QuestionResponse>) => {
-    const fields = Questions.map((q) => q.field);
+    const fields = Questions.map((q) => q.field) as Array<keyof ApplicationResponses>;
     const responses = Questions.map((q) => values[q.id] ?? null);
     setIsSubmitting(true);
     const response = await updateApplicantResponses({ fields, responses });

--- a/components/application/PostAcceptanceForm.tsx
+++ b/components/application/PostAcceptanceForm.tsx
@@ -1,7 +1,12 @@
 import React, { useState } from 'react';
 import { Button, Form, notification, Popconfirm } from 'antd';
 import { useWarnIfUnsavedChanges } from '../hooks/useWarnIfUnsavedChanges';
-import { AttendingState, QuestionResponse, RSVPStatus } from '../../common/types';
+import {
+  AttendingState,
+  PostAcceptanceResponses,
+  QuestionResponse,
+  RSVPStatus,
+} from '../../common/types';
 import { PostAcceptanceFormQuestions, PostAcceptanceFormSections } from '../../common/questions';
 import { getConfirmBy, updatePostAcceptanceFormResponses } from '../../common/apiClient';
 import { FormSectionsAndQuestions } from './FormSectionsAndQuestions';
@@ -83,10 +88,14 @@ const FullForm: React.FC = () => {
   useWarnIfUnsavedChanges(true);
 
   const onSubmit = async (values: Record<string, QuestionResponse>) => {
+    const fields = PostAcceptanceFormQuestions.map((q) => q.field) as Array<
+      keyof PostAcceptanceResponses
+    >;
     const responses = PostAcceptanceFormQuestions.map((q) => values[q.id] ?? null);
     setIsSubmitting(true);
     const response = await updatePostAcceptanceFormResponses({
       rsvpStatus: RSVPStatus.Confirmed,
+      fields,
       responses,
     });
     if (200 <= response.status && response.status < 300) {

--- a/pages/api/v1/registration.ts
+++ b/pages/api/v1/registration.ts
@@ -30,8 +30,8 @@ const getHandler: NextApiHandler = async (req, res) => {
   const { userDataCollection } = await connectToDatabase();
   const data = await userDataCollection.findOne({ email });
   return res.status(200).json({
-    fields: data ? Object.keys(data) : [],
-    responses: data ? Object.values(data) : [],
+    fields: data?.applicationResponses ? Object.keys(data.applicationResponses) : [],
+    responses: data?.applicationResponses ? Object.values(data.applicationResponses) : [],
   });
 };
 
@@ -72,7 +72,7 @@ const postHandler: NextApiHandler = async (req, res) => {
     { email },
     {
       $set: {
-        ...userResponses,
+        applicationResponses: userResponses,
         email,
         applicationStatus: ApplicationStatus.Submitted,
       },


### PR DESCRIPTION
Currently the post-acceptance question responses are still left as an array in the db.
This PR updates the structure of a user in the db to be:
```
{
…,
applicationResponses: {
    gender: ‘Female’,
    hackBeanGoals: ‘asdfasdf’,
    hackathonsAttended: ‘1-2’,
    interestedWorkshops: [
        ‘Remote Hosting’
    ],
    majors: ‘asdf’,
    meetAlienSpeech: ‘asdfasdf’,
    minors: ‘asdf’,
    name: ‘Judy Zhang’,
    prevHackathonFeedback: ‘dfasdfa’,
…
},
postAcceptanceResponses: {
name: “Judy Zhang’,
age: ‘22’,
etc.
}
}
```

Now we should be able to update post acceptance questions while the form is live.