### PR TITLE
Fix stats page

### DIFF
--- a/pages/api/v1/stats.ts
+++ b/pages/api/v1/stats.ts
@@ -25,13 +25,13 @@ const getStats: NextApiHandler = async (req: NextApiRequest, res: NextApiRespons
     .aggregate([{ $group: { _id: '$applicationStatus', count: { $sum: 1 } } }])
     .toArray();
 
-  const statuses = ['Incomplete', 'Submitted']
+  const statuses = ['Incomplete', 'Submitted'];
   const statusDataWithEmpties = statuses.map((status: string) => {
     return {
       _id: status,
       count: statusData.find((e) => e._id === status)?.count ?? 0,
-    }
-  })
+    };
+  });
 
   const shirtData = await userDataCollection
     .aggregate([
@@ -56,13 +56,16 @@ const getStats: NextApiHandler = async (req: NextApiRequest, res: NextApiRespons
     .aggregate([{ $group: { _id: '$decisionStatus', count: { $sum: 1 } } }])
     .toArray();
 
-  const decisionStatuses = ['Admitted', 'Waitlisted', 'Declined', 'Undecided']
+  const decisionStatuses = ['Admitted', 'Waitlisted', 'Declined', 'Undecided'];
   const decisionStatusDataWithEmpties = decisionStatuses.map((decisionStatus) => {
     return {
       _id: decisionStatus,
-      count: decisionStatusData.find((e) => e._id === (decisionStatus === 'Undecided' ? null : decisionStatus))?.count ?? 0
-    }
-  })
+      count:
+        decisionStatusData.find(
+          (e) => e._id === (decisionStatus === 'Undecided' ? null : decisionStatus)
+        )?.count ?? 0,
+    };
+  });
 
   const resData = convertData(
     ['status', 'shirt', 'decisionStatus'],


### PR DESCRIPTION
Fixes #188 

Updates the stats page to include new aggregations, and fix existing aggregations now that we're storing user data differently.

Didn't add any aggregations not defined in the ticket, but they're pretty quick to add - does registration have any opinions on what would be useful?
![image](https://user-images.githubusercontent.com/55663572/198708379-5ae52452-1cd9-41b0-9750-ce5a2f25c55b.png)
