### PR TITLE
Add last names to applicant table

### DIFF
--- a/components/admin-tabs/Applicants.tsx
+++ b/components/admin-tabs/Applicants.tsx
@@ -26,11 +26,18 @@ export type SingleRecordType = ApplicantsApiResponse['data'][number];
 // table columns: name, email, school, application status, rsvp status
 const columns = [
   {
-    title: 'Name',
-    dataIndex: 'applicationResponses.name',
+    title: 'First Name',
+    dataIndex: 'applicationResponses.firstName',
     sorter: true,
     editable: false,
     render: (_: string, record: SingleRecordType) => record.applicationResponses?.firstName ?? '',
+  },
+  {
+    title: 'Last Name',
+    dataIndex: 'applicationResponses.lastName',
+    sorter: true,
+    editable: false,
+    render: (_: string, record: SingleRecordType) => record.applicationResponses?.lastName ?? '',
   },
   {
     title: 'Email',


### PR DESCRIPTION
# Add last names to HBP Application Portal Admin Table

## 🎫 Issue #264 .

### ▶ Changelist:

- Add last names column to the admin table, with the ability to sort last names alphabetically 
- Refactor first name column to use a new index key
- Rename column title to "First Name" instead of "Name"

### 📝 Notes +  🚧 TODO:

- I found lots of weird styling quirks + some outdated components; this is an internal tool so it's not a big deal, but might be worth addressing this summer before it becomes a bigger issue later on!
- I ran into an ``ERR_OSSL_EVP_UNSUPPORTED`` error whenever running ``yarn dev``; a temporary fix is to run ``export NODE_OPTIONS=--openssl-legacy-provider`` before ``yarn dev``, but a more permanent solution is updating lots of our core dependencies like node, webpack, typescript etc.

### 🧪 Testing:

- Manual Testing

### 🎥 Screenshots & Screencasts:
![image](https://github.com/HackBeanpot/application-portal/assets/93111430/88fe5770-954f-4e79-8f84-717832c359b8)