### PR TITLE
Using values instead of keys for dropdown labels

### DIFF
--- a/common/questions.tsx
+++ b/common/questions.tsx
@@ -237,7 +237,7 @@ export const Sections: Array<QuestionSection | QuestionDefinition> = [
         <i>Your gender identity will not be shared publicly or to companies.</i>
       </p>
     </div>,
-    Object.keys(Gender),
+    Object.values(Gender),
     true,
     'Gender'
   ),
@@ -252,7 +252,7 @@ export const Sections: Array<QuestionSection | QuestionDefinition> = [
         <i>Your orientation will not be shared publicly or to companies.</i>
       </p>
     </div>,
-    [Lgbtq.Yes, Lgbtq.No, Lgbtq.PreferNotToSay, Lgbtq.Unsure],
+    Object.values(Lgbtq),
     true,
     'Identify'
   ),


### PR DESCRIPTION
For LGBTQ+ and Gender dropdowns, we were using the keys of the enum instead of the values

Before:
![image](https://github.com/user-attachments/assets/2c5dcbad-159a-4a89-b179-0b12d5d00cfc)

After:
![image](https://github.com/user-attachments/assets/2e25d8b7-abdf-4fcf-9828-5098795948d2)
