### PR TITLE
Clear Applicant Button

### DIFF
--- a/components/admin-tabs/Applicants.tsx
+++ b/components/admin-tabs/Applicants.tsx
@@ -189,11 +189,12 @@ const Applicants: React.FC = () => {
 
   return (
     <div className={'applicants'}>
-      <div className="title-container">
-        <h3 className="title">{ADMIN_TABS.VIEW_AND_MODIFY_APPLICANTS}</h3>
-        <ExportButton cb={downloadApplicationCsv} text="Export Application Responses" />
-        <ExportButton cb={downloadPostAcceptanceCsv} text="Export Post-Acceptance Responses" />
-      </div>
+    <div className="title-container">
+      <h3 className="title">{ADMIN_TABS.VIEW_AND_MODIFY_APPLICANTS}</h3>
+      <ExportButton cb={downloadApplicationCsv} text="Export Application Responses" />
+      <ExportButton cb={downloadPostAcceptanceCsv} text="Export Post-Acceptance Responses" />
+    </div>
+    <Button className="clear-button">Clear Applicant Data</Button>
       <Table
         size={'small'}
         className={'applicants'}

--- a/styles/pages/_Admin.scss
+++ b/styles/pages/_Admin.scss
@@ -13,16 +13,27 @@
     .title-container {
       display: flex;
       flex-direction: row;
-
+ 
+ 
       .title {
         margin-right: auto;
       }
-
+ 
+ 
       .export-button {
         margin-left: 10px;
       }
     }
-  }
+      .clear-button {
+        background-color: red;
+        color:white;
+        margin-left: 1045px;
+      }
+      .clear-button:hover {
+        background-color: lightcoral;
+      }
+    }
+ 
 
   .ant-select-dropdown {
     zoom: 1 !important;


### PR DESCRIPTION
<Summary line - One sentence describing your intended set of changes>
Added a new button on user interface for clearing applicant data for the viewing/modifying applicant button

🎫 Issue #267 

▶ Changelist:
-Added new button for clearing applicant data directly underneath export buttons
-Added styling code in admin file to position button and change it to lighter red on hovering

📝 Notes + 🚧 TODO:
- Part of this ticket included adding a save responses button, however, this was already implemented in codebase (both frontend and backend logic). The last saved functionality also looks to be done (#273)
- Button's position was hardcoded to a certain px value, this may cause different views on different sized screens. When reviewing, please let me know if the positioning is off.

🧪 Testing:
-Manual testing of both application and admin screens on desktop

🎥 Screenshots & Screencasts:
<img width="1792" alt="Screenshot 2025-07-03 at 12 55 47 PM" src="https://github.com/user-attachments/assets/dafbf833-117e-4a44-b235-3cc4076ca8b1" />
<img width="1792" alt="Screenshot 2025-07-03 at 12 56 09 PM" src="https://github.com/user-attachments/assets/4594dc3b-c329-4660-9aa8-49de28c82b2b" />
